### PR TITLE
Default field values should be added to responses as clones, rather than by reference

### DIFF
--- a/lib/orpheus.coffee
+++ b/lib/orpheus.coffee
@@ -4,6 +4,7 @@
 _            = require 'underscore'           
 async        = require 'async'        
 os           = require 'os'
+clone        = require 'clone'
 
 inflector    = require './inflector'
 commands     = require './commands'
@@ -797,14 +798,20 @@ class OrpheusAPI
 			else
 				new_res[s.name] = res[i]
 			
-			# If the field is empty - undefined, null, {}, []
-			# then user the field's default or delete the field
-			# if there's no default.
+			# Get a quick reference to the current response field
 			field = new_res[s.name]
+			# If the field is `undefined`, `null`, or an empty object or array, then we
+			# either use the field's default value or delete it from the response if
+			# there's no default value.
 			if _.isNull(field) or _.isUndefined(field) or (_.isObject(field) and _.isEmpty(field))
+				# If no default value was set on the field, we delete it from the response.
+				# Otherwise, we clone the default value and add it as the field in the response.
 				if _.isUndefined @model[s.name].options.default
-				then delete new_res[s.name]
-				else new_res[s.name] = @model[s.name].options.default
+					# Delete the field from the response
+					delete new_res[s.name]
+				else
+					# Clone the default value of the field, and add it to the response
+					new_res[s.name] = clone(@model[s.name].options.default)
 
 		# Return the new response
 		return new_res

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
 	},
 	"dependencies": {
 		"async": "0.1.22",
-		"underscore": "1.4.3"
+		"underscore": "1.4.3",
+		"clone": "1.0.2"
 	},
 	"bugs": {
 		"url": "http://github.com/Radagaisus/Orpheus/issues"


### PR DESCRIPTION
This solves an issue where modifying responses would "pollute" default values for other queries.

- Now using the `node-clone` package, version 1.0.2
- Fixed the issue: default values will be cloned before being added to the response
- Prettified the code around the cloning of the default value a bit
- Added a validation test

```coffee
	# This test validates that default field values are cloned and passed by-value
	# to the response, rather than by-reference. If the end-user tries to modify
	# a response that contains by-reference default fields, this can "pollute"
	# default values for other queries. The scenario we test here:
	# 
	# 1. Every reader has a set of books that defaults to an empty array.
	# 2. We retrieve the first reader's (empty) list of books
	# 3. We update that list with a new book that that reader has read
	# 4. We retrieve the second reader's (empty) list of books.
	# 
	# When default values are passed by-reference, this would've caused the second
	# reader's list of books to be "polluted" with the first readers book. Cloning
	# the default value takes care of this.
	# 
	it 'Default field values are returned in the response as clones', (done) ->	
		# Define a new Reader model, that holds a set of books they've read, that
		# defaults to an empty array. Arrays are by-reference in JavaScript.
		class Reader extends Orpheus
			constructor: ->
				@set 'books', default: []
		# Create the reader API
		reader = Reader.create()
		# Retrieve the first reader's books. The first reader has no books yet,
		# so this will return the default value - an empty array.
		reader('first').books.members().exec (err, res) ->
			# Update the reader's books with a new book they've read.
			res.books.push('The Great Hunt')
			# Update the books set for the first reader in the database. This step
			# is not really needed for the test, but it helps illustrate a real
			# world scenario for this issue.
			reader('first').books.add(res.books).exec (err, res) ->
				# Retrieve the books of the second reader. The second reader has no
				# books yet, so we expect the list to be empty. The bug we test here
				# would have caused the empty default array to be "polluted" with the
				# first reader's books.
				reader('second').books.members().exec (err, res) ->
					# Check that the books list is empty
					expect(res.books.length).toEqual 0
					# We're done.
					done()
```

