### PR TITLE
update the redis package dependency

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 
 ## 0.6.4
 
-- Update the redis package dependency.
+- Updated `node_redis` dependency to 0.12.1.
 
 ## 0.6.3
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.4
+
+- Update the redis package dependency.
+
 ## 0.6.3
 
 - Added node.js 0.12 and io.js to the CI.

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
 	"name": "orpheus",
 	"description": "Redis Object Model for CoffeeScript",
-	"version": "0.6.3",
+	"version": "0.6.4",
 	"url": "https://github.com/Radagaisus/Orpheus",
 	"author": "Almog Melamed <radagaisus@gmail.com",
 	"main": "./index",
 	"devDependencies": {
 		"jasmine-node": "latest",
 		"metrics": "0.1.6",
-		"redis": "0.10.0"
+		"redis": "0.12.1"
 	},
 	"dependencies": {
 		"async": "0.1.22",


### PR DESCRIPTION
the `node-redis` package is now in version 12.1 so its time to update.
It fix some issues, update the command set to match redis 2.8.9 and have a better support for node 0.12.