### PR TITLE
update to node-redis 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ node_js:
     - "0.10"
     - "0.12"
     - "iojs"
+    - "4.0"
+    - "4.1"
+    - "4.2"
 before_script:
     - "npm i -g jasmine-node"
 services:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.0
+
+- Update the underlying redis driver, `node-redis` from 0.10.2 to 2.3.0. This does not change any behavior for Orpheus, but the driver itself has some breaking changes.
+- Added node.js version `4.0`, `4.1`, `4.2` to the CI.
+
 ## 0.6.5
 
 - Updated Orpheus to support all the latest and greatest Redis commands:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "orpheus",
 	"description": "Redis Object Model for CoffeeScript",
-	"version": "0.6.5",
+	"version": "0.7",
 	"url": "https://github.com/Radagaisus/Orpheus",
 	"author": "Almog Melamed <radagaisus@gmail.com",
 	"main": "./index",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	"devDependencies": {
 		"jasmine-node": "latest",
 		"metrics": "0.1.6",
-		"redis": "0.12.1"
+		"redis": "2.3.0"
 	},
 	"dependencies": {
 		"async": "0.1.22",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "orpheus",
 	"description": "Redis Object Model for CoffeeScript",
-	"version": "0.7",
+	"version": "0.7.0",
 	"url": "https://github.com/Radagaisus/Orpheus",
 	"author": "Almog Melamed <radagaisus@gmail.com",
 	"main": "./index",


### PR DESCRIPTION
Updating to use `node-redis` version 2.3.0.
The update went flawlessly without any need for changes in our code.

The only breaking changes reported in `node-redis` were in `2.0.0` and is explained here: https://github.com/NodeRedis/node_redis/releases/tag/v.2.0.0
There isn't anything there that is related to Orpheus.

Also added node.js versions `4.0`, `4.1`, `4.2` to the CI.

Everything looks good, all tests pass, we can roll this out.